### PR TITLE
Add rise to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 jupyter
+rise
+
+# The following packages are only required for the example
+# notebook. You should replace them with the dependencies
+# of your notebook.
 sme
 sme_contrib
 matplotlib


### PR DESCRIPTION
Additionally, this adds a comment that separates necessary requirements from application-specific ones.